### PR TITLE
Issue #104 - treat eol commas as trailing whitespace

### DIFF
--- a/lib/standard-clojure-style.js
+++ b/lib/standard-clojure-style.js
@@ -1040,6 +1040,10 @@
     return nodes
   }
 
+  function removeLeadingWhitespace (txt) {
+    return strReplace(txt, /^[, ]*\n+ */, '')
+  }
+
   // Starting from idx, is the next line a line where there is only a comment and nothing else?
   function isNextLineACommentLine (nodes, idx) {
     const n1 = nodes[idx]
@@ -3216,7 +3220,7 @@
           }
 
           if (isCommaNode(node)) {
-            const commaTrail = strReplace(node.text, /^\n+ +/, '')
+            const commaTrail = removeLeadingWhitespace(node.text)
             const trimmedCommaTrail = rtrim(commaTrail)
             indentationStr = strConcat(indentationStr, trimmedCommaTrail)
           }
@@ -3380,6 +3384,7 @@
     API._substr = substr
     API._commentNeedsSpaceBefore = commentNeedsSpaceBefore
     API._commentNeedsSpaceInside = commentNeedsSpaceInside
+    API._removeLeadingWhitespace = removeLeadingWhitespace
 
     API._AnyChar = AnyChar
     API._Char = Char

--- a/lib/standard-clojure-style.js
+++ b/lib/standard-clojure-style.js
@@ -3062,15 +3062,25 @@
       if (parenStackSize > 0 && !insideNsForm) {
         const isCommentFollowedByNewline = isCommentNode(node) && nextTextNode && isNewlineNode(nextTextNode)
         const isNewline = isNewlineNode(node)
-        const isNewlineWithComma = isCommaNode(node) || (nextTextNode && isCommaNode(nextTextNode))
+
+        // const isNewlineWithComma = isCommaNode(node) || (nextTextNode && isCommaNode(nextTextNode))
 
         // FIXME: we need a new version of isNewlineWithComma that is only true
         // if the commas are AFTER the newline character
         // const isNewlineWithComma = false
-        // const hasCommasAfterNewline2 = hasCommasAfterNewline(node) || (nextTextNode && hasCommasAfterNewline(node))
 
-        if ((isCommentFollowedByNewline || isNewline) && !isNewlineWithComma) {
-        // if ((isCommentFollowedByNewline || isNewline) && !hasCommasAfterNewline2) {
+        const hasCommasAfterNewline2 = hasCommasAfterNewline(node) || (nextTextNode && hasCommasAfterNewline(nextTextNode))
+
+        let lookForwardToSlurpNodes = false
+        if (hasCommasAfterNewline2) {
+          lookForwardToSlurpNodes = false
+        } else if (isCommentFollowedByNewline) {
+          lookForwardToSlurpNodes = true
+        } else if (isNewline) {
+          lookForwardToSlurpNodes = true
+        }
+
+        if (lookForwardToSlurpNodes) {
           // look forward and grab any closers nodes that may be slurped up
           const parenTrailClosers = findForwardClosingParens(nodesArr, inc(idx))
 
@@ -3078,10 +3088,7 @@
           const lastNodeWePrinted = arrayLast(nodesWeHavePrintedOnThisLine)
           let lineTxtHasBeenRightTrimmed = false
           if (lastNodeWePrinted && isWhitespaceNode(lastNodeWePrinted)) {
-            // console.log('xxx' + lastNodeWePrinted.text + "xxx")
             lineTxt = rtrim(lineTxt)
-            // lineTxt = removeLeadingWhitespace(lineTxt)
-            // lineTxt = trimmedCommaTrail
             lineTxtHasBeenRightTrimmed = true
           }
 

--- a/lib/standard-clojure-style.js
+++ b/lib/standard-clojure-style.js
@@ -3062,13 +3062,6 @@
       if (parenStackSize > 0 && !insideNsForm) {
         const isCommentFollowedByNewline = isCommentNode(node) && nextTextNode && isNewlineNode(nextTextNode)
         const isNewline = isNewlineNode(node)
-
-        // const isNewlineWithComma = isCommaNode(node) || (nextTextNode && isCommaNode(nextTextNode))
-
-        // FIXME: we need a new version of isNewlineWithComma that is only true
-        // if the commas are AFTER the newline character
-        // const isNewlineWithComma = false
-
         const hasCommasAfterNewline2 = hasCommasAfterNewline(node) || (nextTextNode && hasCommasAfterNewline(nextTextNode))
 
         let lookForwardToSlurpNodes = false

--- a/lib/standard-clojure-style.js
+++ b/lib/standard-clojure-style.js
@@ -3220,8 +3220,8 @@
           }
 
           if (isCommaNode(node)) {
-            const commaTrail = removeLeadingWhitespace(node.text)
-            const trimmedCommaTrail = rtrim(commaTrail)
+            const nextLineCommaTrail = removeLeadingWhitespace(node.text)
+            const trimmedCommaTrail = rtrim(nextLineCommaTrail)
             indentationStr = strConcat(indentationStr, trimmedCommaTrail)
           }
 

--- a/lib/standard-clojure-style.js
+++ b/lib/standard-clojure-style.js
@@ -237,6 +237,10 @@
     return s.replace(find, replace)
   }
 
+  function strSplit (str, ch) {
+    return str.split(ch)
+  }
+
   // ---------------------------------------------------------------------------
   // id generator
 
@@ -998,8 +1002,7 @@
   }
 
   function numSpacesAfterNewline (newlineNode) {
-    // TODO: make this language neutral
-    const x = newlineNode.text.split('\n')
+    const x = strSplit(newlineNode.text, '\n')
     const lastX = arrayLast(x)
     return strLen(lastX)
   }
@@ -1041,7 +1044,19 @@
   }
 
   function removeLeadingWhitespace (txt) {
-    return strReplace(txt, /^[, ]*\n+ */, '')
+    return rtrim(strReplace(txt, /^[, ]*\n+ */, ''))
+  }
+
+  function removeTrailingWhitespace (txt) {
+    return strReplace(txt, /[, ]*$/, '')
+  }
+
+  function txtHasCommasAfterNewline (s) {
+    return /\n.*,.*$/.test(s)
+  }
+
+  function hasCommasAfterNewline (node) {
+    return isWhitespaceNode(node) && txtHasCommasAfterNewline(node.text)
   }
 
   // Starting from idx, is the next line a line where there is only a comment and nothing else?
@@ -1111,7 +1126,7 @@
   }
 
   function parseJavaPackageWithClass (s) {
-    const chunks = s.split('.') // TODO: make language neutral
+    const chunks = strSplit(s, '.')
     const lastItm = arrayLast(chunks)
 
     if (looksLikeAJavaClassname(lastItm)) {
@@ -3049,7 +3064,13 @@
         const isNewline = isNewlineNode(node)
         const isNewlineWithComma = isCommaNode(node) || (nextTextNode && isCommaNode(nextTextNode))
 
+        // FIXME: we need a new version of isNewlineWithComma that is only true
+        // if the commas are AFTER the newline character
+        // const isNewlineWithComma = false
+        // const hasCommasAfterNewline2 = hasCommasAfterNewline(node) || (nextTextNode && hasCommasAfterNewline(node))
+
         if ((isCommentFollowedByNewline || isNewline) && !isNewlineWithComma) {
+        // if ((isCommentFollowedByNewline || isNewline) && !hasCommasAfterNewline2) {
           // look forward and grab any closers nodes that may be slurped up
           const parenTrailClosers = findForwardClosingParens(nodesArr, inc(idx))
 
@@ -3057,7 +3078,10 @@
           const lastNodeWePrinted = arrayLast(nodesWeHavePrintedOnThisLine)
           let lineTxtHasBeenRightTrimmed = false
           if (lastNodeWePrinted && isWhitespaceNode(lastNodeWePrinted)) {
+            // console.log('xxx' + lastNodeWePrinted.text + "xxx")
             lineTxt = rtrim(lineTxt)
+            // lineTxt = removeLeadingWhitespace(lineTxt)
+            // lineTxt = trimmedCommaTrail
             lineTxtHasBeenRightTrimmed = true
           }
 
@@ -3227,7 +3251,8 @@
 
           // add this line to the outTxt and reset lineTxt
           if (strTrim(lineTxt) !== '') {
-            outTxt = strConcat(outTxt, lineTxt)
+            const whitespaceTrimmedLineTxt = removeTrailingWhitespace(lineTxt)
+            outTxt = strConcat(outTxt, whitespaceTrimmedLineTxt)
           }
           outTxt = strConcat(outTxt, newlineStr)
 
@@ -3385,6 +3410,7 @@
     API._commentNeedsSpaceBefore = commentNeedsSpaceBefore
     API._commentNeedsSpaceInside = commentNeedsSpaceInside
     API._removeLeadingWhitespace = removeLeadingWhitespace
+    API._txtHasCommasAfterNewline = txtHasCommasAfterNewline
 
     API._AnyChar = AnyChar
     API._Char = Char

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -70,7 +70,7 @@ test('All test_format/ cases should have unique names', () => {
 // only those cases will run
 const onlyRunSpecificTests = false
 const specificTests = new Set()
-specificTests.add('Trim trailing whitespace 2')
+// specificTests.add('your test case here')
 
 const ignoreSomeTests = true
 const ignoreTests = new Set()

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -68,7 +68,7 @@ test('All test_format/ cases should have unique names', () => {
 
 // dev convenience: set this to true and add specific test cases
 // only those cases will run
-const onlyRunSpecificTests = true
+const onlyRunSpecificTests = false
 const specificTests = new Set()
 specificTests.add('Trim trailing whitespace 2')
 

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -68,9 +68,9 @@ test('All test_format/ cases should have unique names', () => {
 
 // dev convenience: set this to true and add specific test cases
 // only those cases will run
-const onlyRunSpecificTests = false
+const onlyRunSpecificTests = true
 const specificTests = new Set()
-// specificTests.add('your test case here')
+specificTests.add('Trim trailing whitespace 2')
 
 const ignoreSomeTests = true
 const ignoreTests = new Set()
@@ -110,7 +110,7 @@ allTestCases.forEach(testCase => {
     }
     if (testCase.name === 'Trim trailing whitespace 2') {
       test('Trim trailing whitespace test case should not be trimmed', () => {
-        expect(testCase.input.includes('"aaa"   \n)(def')).toBe(true)
+        expect(testCase.input.includes('"aaa",   \n)(def')).toBe(true)
       })
     }
     if (testCase.name === 'Surrounding newlines removed additional') {

--- a/test/internals.test.js
+++ b/test/internals.test.js
@@ -47,6 +47,15 @@ test('commentNeedsSpaceInside', () => {
   expect(scsLib._commentNeedsSpaceInside(';;;;;;')).toBe(false)
 })
 
+test('removeLeadingWhitespace', () => {
+  expect(scsLib._removeLeadingWhitespace('\n ,,')).toBe(',,')
+  expect(scsLib._removeLeadingWhitespace(' \n ')).toBe('')
+  expect(scsLib._removeLeadingWhitespace('  \n\n  ')).toBe('')
+  expect(scsLib._removeLeadingWhitespace(',, \n ')).toBe('')
+  expect(scsLib._removeLeadingWhitespace(',, \n\n ')).toBe('')
+  expect(scsLib._removeLeadingWhitespace(',, \n\n')).toBe('')
+})
+
 test('AnyChar parser', () => {
   const anyCharTest1 = scsLib._AnyChar({ name: 'anychar_test1' })
   expect(anyCharTest1.parse('a', 0).text).toBe('a')

--- a/test/internals.test.js
+++ b/test/internals.test.js
@@ -56,6 +56,15 @@ test('removeLeadingWhitespace', () => {
   expect(scsLib._removeLeadingWhitespace(',, \n\n')).toBe('')
 })
 
+test('txtHasCommasAfterNewline', () => {
+  expect(scsLib._txtHasCommasAfterNewline('\n ,,')).toBe(true)
+  expect(scsLib._txtHasCommasAfterNewline('\n\n  ,')).toBe(true)
+  expect(scsLib._txtHasCommasAfterNewline(' \n ')).toBe(false)
+  expect(scsLib._txtHasCommasAfterNewline('  \n\n  ')).toBe(false)
+  expect(scsLib._txtHasCommasAfterNewline(',, \n ')).toBe(false)
+  expect(scsLib._txtHasCommasAfterNewline(',, \n\n ')).toBe(false)
+})
+
 test('AnyChar parser', () => {
   const anyCharTest1 = scsLib._AnyChar({ name: 'anychar_test1' })
   expect(anyCharTest1.parse('a', 0).text).toBe('a')

--- a/test_format/format.eno
+++ b/test_format/format.eno
@@ -1321,3 +1321,24 @@ eee)
 (-> #js ddd
   eee)
 --Expected
+
+# GitHub Issue #104 - treat eol commas as trailing whitespace
+
+> https://github.com/oakmac/standard-clojure-style-js/issues/104
+
+--Input
+(aaa,
+   bbb),
+
+(ccc ,,
+  :ddd
+  )   ,
+--Input
+
+--Expected
+(aaa
+  bbb)
+
+(ccc
+  :ddd)
+--Expected

--- a/test_format/trailing_whitespace.eno
+++ b/test_format/trailing_whitespace.eno
@@ -13,7 +13,7 @@
 > NOTE: there is a test case that checks whether this test case input has trailing whitespace
 
 --Input
-(def aaa "aaa"   
+(def aaa "aaa",   
 )(def bbb "bbb")
 --Input
 


### PR DESCRIPTION
[Issue #104](https://github.com/oakmac/standard-clojure-style-js/issues/104)

* treats eol commas as whitespace and removes them