### PR TITLE
Issue #181 - ns metadata hashmap with quoted value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- [Issue #181] - fix bug with quoted map value in `ns` hash map metadata ([PR-182])
+
 ## [0.20.0] - 2025-02-01
 
 ### Fixed
@@ -231,6 +234,7 @@ All notable changes to this project will be documented in this file.
 [Issue #165]:https://github.com/oakmac/standard-clojure-style-js/issues/165
 [Issue #166]:https://github.com/oakmac/standard-clojure-style-js/issues/166
 [Issue #178]:https://github.com/oakmac/standard-clojure-style-js/issues/178
+[Issue #181]:https://github.com/oakmac/standard-clojure-style-js/issues/181
 
 [commit #db857ff4]:https://github.com/oakmac/standard-clojure-style-js/commit/db857ff413f0a8625c0cd0c975684244d875705e
 
@@ -277,3 +281,4 @@ All notable changes to this project will be documented in this file.
 [PR-171]:https://github.com/oakmac/standard-clojure-style-js/pull/171
 [PR-177]:https://github.com/oakmac/standard-clojure-style-js/pull/177
 [PR-179]:https://github.com/oakmac/standard-clojure-style-js/pull/179
+[PR-182]:https://github.com/oakmac/standard-clojure-style-js/pull/182

--- a/lib/standard-clojure-style.js
+++ b/lib/standard-clojure-style.js
@@ -818,6 +818,10 @@
     return n && n.name === '.close' && (n.text === ')' || n.text === ']' || n.text === '}')
   }
 
+  function isWrap (n) {
+    return n && n.name === 'wrap'
+  }
+
   function isTokenNode (n) {
     return n.name === 'token'
   }
@@ -1841,7 +1845,9 @@
           metadataValueNodeId = -1
 
           // skip any forward nodes that we have just collected as text
-          if (isArray(node.children)) {
+          if (isWrap(node)) {
+            skipNodesUntilWeReachThisId = node.id
+          } else if (isArray(node.children)) {
             const lastChildNode = arrayLast(node.children)
             skipNodesUntilWeReachThisId = lastChildNode.id
           }

--- a/lib/standard-clojure-style.js
+++ b/lib/standard-clojure-style.js
@@ -1845,10 +1845,16 @@
           metadataValueNodeId = -1
 
           // skip any forward nodes that we have just collected as text
+          let unwrappedNode
           if (isWrap(node)) {
-            skipNodesUntilWeReachThisId = node.id
-          } else if (isArray(node.children)) {
-            const lastChildNode = arrayLast(node.children)
+            const wrapBody = arrayLast(node.children)
+            unwrappedNode = arrayLast(wrapBody.children)
+          } else {
+            unwrappedNode = node
+          }
+
+          if (isArray(unwrappedNode.children)) {
+            const lastChildNode = arrayLast(unwrappedNode.children)
             skipNodesUntilWeReachThisId = lastChildNode.id
           }
         }

--- a/test_parse_ns/parse_ns.eno
+++ b/test_parse_ns/parse_ns.eno
@@ -3053,3 +3053,24 @@
   "nsSymbol": "com.example.my-app"
 }
 --Expected
+
+# GitHub Issue #181 - ns metadata hash map with quoted value
+
+> https://github.com/oakmac/standard-clojure-style-js/issues/181
+
+--Input
+(ns my.namespace
+  {:clj-kondo/config '{:linters {:unresolved-symbol {:level :off}}}})
+--Input
+
+--Expected
+ {
+  "nsSymbol": "my.namespace",
+  "nsMetadata": [
+    {
+      "key": ":clj-kondo/config",
+      "value": "'{:linters {:unresolved-symbol {:level :off}}}"
+    }
+  ]
+}
+--Expected

--- a/test_parse_ns/parse_ns.eno
+++ b/test_parse_ns/parse_ns.eno
@@ -3060,7 +3060,8 @@
 
 --Input
 (ns my.namespace
-  {:clj-kondo/config '{:linters {:unresolved-symbol {:level :off}}}})
+  {:clj-kondo/config '{:linters {:unresolved-symbol {:level :off}}}}
+  (:require [clojure.string :as str]))
 --Input
 
 --Expected
@@ -3070,6 +3071,12 @@
     {
       "key": ":clj-kondo/config",
       "value": "'{:linters {:unresolved-symbol {:level :off}}}"
+    }
+  ],
+  "requires": [
+    {
+      "symbol": "clojure.string",
+      "as": "str"
     }
   ]
 }


### PR DESCRIPTION
This PR fixes an issue with ns metadata hashmap when the value is a quoted map.

After collecting the metadata value, we need to skip until the end of the collected values. If the node is a wrap node, the lastChildNode.id is the wrap node body. We need to skip more than that to the end of the wrap node.