### PR TITLE
GitHub Issue #184 - tagged literals in ns metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- [Issue #184] - fix bug with tagged literals in `ns` metadata ([PR-185])
+
 ## [0.21.0] - 2025-02-26
 
 ### Fixed
@@ -238,6 +240,7 @@ All notable changes to this project will be documented in this file.
 [Issue #166]:https://github.com/oakmac/standard-clojure-style-js/issues/166
 [Issue #178]:https://github.com/oakmac/standard-clojure-style-js/issues/178
 [Issue #181]:https://github.com/oakmac/standard-clojure-style-js/issues/181
+[Issue #184]:https://github.com/oakmac/standard-clojure-style-js/issues/184
 
 [commit #db857ff4]:https://github.com/oakmac/standard-clojure-style-js/commit/db857ff413f0a8625c0cd0c975684244d875705e
 
@@ -285,3 +288,4 @@ All notable changes to this project will be documented in this file.
 [PR-177]:https://github.com/oakmac/standard-clojure-style-js/pull/177
 [PR-179]:https://github.com/oakmac/standard-clojure-style-js/pull/179
 [PR-182]:https://github.com/oakmac/standard-clojure-style-js/pull/182
+[PR-185]:https://github.com/oakmac/standard-clojure-style-js/pull/185

--- a/lib/standard-clojure-style.js
+++ b/lib/standard-clojure-style.js
@@ -971,6 +971,10 @@
   function getTextFromRootNode (rootNode) {
     let s = ''
     recurseAllChildren(rootNode, n => {
+      // edge case: add '#' text to .tag nodes
+      if (isTagNode(n)) {
+        s = strConcat(s, '#')
+      }
       if (isStringWithChars(n.text)) {
         s = strConcat(s, n.text)
       }

--- a/test_parse_ns/parse_ns.eno
+++ b/test_parse_ns/parse_ns.eno
@@ -3081,3 +3081,31 @@
   ]
 }
 --Expected
+
+# GitHub Issue 184 - Bug: ns metadata tagged literal values printed without hash
+
+> https://github.com/oakmac/standard-clojure-style-js/issues/184
+
+--Input
+(ns com.example.my-app
+  {:id #uuid "7f5f474f-1c76-4884-af80-8ebdcf5c9df3"}
+  (:require [clojure.string :as str]))
+--Input
+
+--Expected
+ {
+  "nsSymbol": "com.example.my-app",
+  "nsMetadata": [
+    {
+      "key": ":id",
+      "value": "#uuid \"7f5f474f-1c76-4884-af80-8ebdcf5c9df3\""
+    }
+  ],
+  "requires": [
+    {
+      "symbol": "clojure.string",
+      "as": "str"
+    }
+  ]
+}
+--Expected


### PR DESCRIPTION
Tagged literal values in namespace metadata are missing the hash '#'.

formatNodes function handles the edge case for adding '#' text tot .tag nodes. However, ns metadata doesn't use formatNodes, instead it collects the values as text. Thus, we need to add the same edge case handling to the text collecting.