### PR TITLE
GitHub Issue #183 - Improve quoted ns metadata handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - [Issue #184] - fix bug with tagged literals in `ns` metadata ([PR-185])
+- [Issue #183] - fix bug with quoted values other than maps, lists etc. in `ns` metadata ([PR-186])
 
 ## [0.21.0] - 2025-02-26
 
@@ -240,6 +241,7 @@ All notable changes to this project will be documented in this file.
 [Issue #166]:https://github.com/oakmac/standard-clojure-style-js/issues/166
 [Issue #178]:https://github.com/oakmac/standard-clojure-style-js/issues/178
 [Issue #181]:https://github.com/oakmac/standard-clojure-style-js/issues/181
+[Issue #183]:https://github.com/oakmac/standard-clojure-style-js/issues/183
 [Issue #184]:https://github.com/oakmac/standard-clojure-style-js/issues/184
 
 [commit #db857ff4]:https://github.com/oakmac/standard-clojure-style-js/commit/db857ff413f0a8625c0cd0c975684244d875705e
@@ -289,3 +291,4 @@ All notable changes to this project will be documented in this file.
 [PR-179]:https://github.com/oakmac/standard-clojure-style-js/pull/179
 [PR-182]:https://github.com/oakmac/standard-clojure-style-js/pull/182
 [PR-185]:https://github.com/oakmac/standard-clojure-style-js/pull/185
+[PR-186]:https://github.com/oakmac/standard-clojure-style-js/pull/186

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- [Issue #184] - fix bug with tagged literals in `ns` metadata ([PR-185])
+
 ## [0.21.0] - 2025-02-26
 
 ### Fixed
@@ -238,6 +240,7 @@ All notable changes to this project will be documented in this file.
 [Issue #166]:https://github.com/oakmac/standard-clojure-style-js/issues/166
 [Issue #178]:https://github.com/oakmac/standard-clojure-style-js/issues/178
 [Issue #181]:https://github.com/oakmac/standard-clojure-style-js/issues/181
+[Issue #184]:https://github.com/oakmac/standard-clojure-style-js/issues/184
 
 [commit #db857ff4]:https://github.com/oakmac/standard-clojure-style-js/commit/db857ff413f0a8625c0cd0c975684244d875705e
 
@@ -285,3 +288,4 @@ All notable changes to this project will be documented in this file.
 [PR-177]:https://github.com/oakmac/standard-clojure-style-js/pull/177
 [PR-179]:https://github.com/oakmac/standard-clojure-style-js/pull/179
 [PR-182]:https://github.com/oakmac/standard-clojure-style-js/pull/182
+[PR-185]:https://github.com/oakmac/standard-clojure-style-js/pull/185

--- a/lib/standard-clojure-style.js
+++ b/lib/standard-clojure-style.js
@@ -818,10 +818,6 @@
     return n && n.name === '.close' && (n.text === ')' || n.text === ']' || n.text === '}')
   }
 
-  function isWrap (n) {
-    return n && n.name === 'wrap'
-  }
-
   function isTokenNode (n) {
     return n.name === 'token'
   }
@@ -1849,17 +1845,14 @@
           metadataValueNodeId = -1
 
           // skip any forward nodes that we have just collected as text
-          let unwrappedNode
-          if (isWrap(node)) {
-            const wrapBody = arrayLast(node.children)
-            unwrappedNode = arrayLast(wrapBody.children)
-          } else {
-            unwrappedNode = node
-          }
-
-          if (isArray(unwrappedNode.children)) {
-            const lastChildNode = arrayLast(unwrappedNode.children)
-            skipNodesUntilWeReachThisId = lastChildNode.id
+          let skipCandidate = node
+          while (skipCandidate) {
+            if (isArray(skipCandidate.children)) {
+              skipCandidate = arrayLast(skipCandidate.children)
+              skipNodesUntilWeReachThisId = skipCandidate.id
+            } else {
+              skipCandidate = null
+            }
           }
         }
 

--- a/lib/standard-clojure-style.js
+++ b/lib/standard-clojure-style.js
@@ -971,6 +971,10 @@
   function getTextFromRootNode (rootNode) {
     let s = ''
     recurseAllChildren(rootNode, n => {
+      // edge case: add '#' text to .tag nodes
+      if (isTagNode(n)) {
+        s = strConcat(s, '#')
+      }
       if (isStringWithChars(n.text)) {
         s = strConcat(s, n.text)
       }

--- a/test_parse_ns/parse_ns.eno
+++ b/test_parse_ns/parse_ns.eno
@@ -3109,3 +3109,71 @@
   ]
 }
 --Expected
+
+# GitHub Issue #183 - handle all types of quoted ns metadata hash map values
+
+> https://github.com/oakmac/standard-clojure-style-js/issues/183
+
+--Input
+(ns my.namespace
+  {:token 'token
+   :string '"string"
+   :parens '(parens)
+   :brackets '[brackets]
+   :braces '{:braces true}
+   :wrap ''wrap
+   :deep-wrap ''''''wrap
+   :meta '^:meta [1 2 3]
+   :tagged ' #tag [1 2 3]}
+  (:require [clojure.string :as str]))
+--Input
+
+--Expected
+ {
+  "nsSymbol": "my.namespace",
+  "nsMetadata": [
+    {
+      "key": ":token",
+      "value": "'token"
+    },
+    {
+      "key": ":string",
+      "value": "'\"string\""
+    },
+    {
+      "key": ":parens",
+      "value": "'(parens)"
+    },
+    {
+      "key": ":brackets",
+      "value": "'[brackets]"
+    },
+    {
+      "key": ":braces",
+      "value": "'{:braces true}"
+    },
+    {
+      "key": ":wrap",
+      "value": "''wrap"
+    },
+    {
+      "key": ":deep-wrap",
+      "value": "''''''wrap"
+    },
+    {
+      "key": ":meta",
+      "value": "'^:meta [1 2 3]"
+    },
+    {
+      "key": ":tagged",
+      "value": "' #tag [1 2 3]"
+    }
+  ],
+  "requires": [
+    {
+      "symbol": "clojure.string",
+      "as": "str"
+    }
+  ]
+}
+--Expected

--- a/test_parse_ns/parse_ns.eno
+++ b/test_parse_ns/parse_ns.eno
@@ -3081,3 +3081,31 @@
   ]
 }
 --Expected
+
+# GitHub Issue 184 - Bug: ns metadata tagged literal values printed without hash
+
+> https://github.com/oakmac/standard-clojure-style-js/issues/184
+
+--Input
+(ns com.example.my-app
+  {:id #uuid "7f5f474f-1c76-4884-af80-8ebdcf5c9df3"}
+  (:require [clojure.string :as str]))
+--Input
+
+--Expected
+ {
+  "nsSymbol": "com.example.my-app",
+  "nsMetadata": [
+    {
+      "key": ":id",
+      "value": "#uuid \"7f5f474f-1c76-4884-af80-8ebdcf5c9df3\""
+    }
+  ],
+  "requires": [
+    {
+      "symbol": "clojure.string",
+      "as": "str"
+    }
+  ]
+}
+--Expected


### PR DESCRIPTION
This PR is built on top of PR #185 

This PR improves quoted namespace metadata value handling.

Pull Request #182 added quoted ns metadata value handling for nodes with children (maps, lists etc.) but didn't address all the possible types a wrap node body might have.

This commit checks if the skip target candidate node has children, and if yes it picks the last child and repeats the check until it finds the correct skip target.