### PR TITLE
Add Cursive for JetBrains IntelliJ IDEA to editor integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ your editor, on the web, CLI tooling, etc.
 
 - Example Emacs usage [in this post](https://x.com/ovstoica/status/1854192289498706012)
 - [Neovim plugin](https://git.sr.ht/~ioiojo/standard-clojure-style.nvim)
+- [Cursive for JetBrains IntelliJ IDEA](https://cursive-ide.com/)
 
 ### Implementations in Other Programming Languages
 


### PR DESCRIPTION
Cursive supports the Standard Clojure Style since version 2026.1, see https://cursive-ide.com/blog/cursive-2026.1.html.