### PR TITLE
Exit gracefully using process.exitCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- [Issue #213] - fix bug with large file output cut short when using standard-clj with stdin/stdout ([PR-214])
+
 ## [0.27.0] - 2026-03-09
 
 ### Added
@@ -287,6 +293,7 @@ All notable changes to this project will be documented in this file.
 [Issue #203]:https://github.com/oakmac/standard-clojure-style-js/issues/203
 [Issue #205]:https://github.com/oakmac/standard-clojure-style-js/issues/205
 [Issue #208]:https://github.com/oakmac/standard-clojure-style-js/issues/208
+[Issue #213]:https://github.com/oakmac/standard-clojure-style-js/issues/213
 
 [commit #db857ff4]:https://github.com/oakmac/standard-clojure-style-js/commit/db857ff413f0a8625c0cd0c975684244d875705e
 
@@ -342,3 +349,4 @@ All notable changes to this project will be documented in this file.
 [PR-204]:https://github.com/oakmac/standard-clojure-style-js/pull/204
 [PR-206]:https://github.com/oakmac/standard-clojure-style-js/pull/206
 [PR-209]:https://github.com/oakmac/standard-clojure-style-js/pull/209
+[PR-214]:https://github.com/oakmac/standard-clojure-style-js/pull/214

--- a/cli.mjs
+++ b/cli.mjs
@@ -88,14 +88,14 @@ function exitHappy (s) {
   if (cliUtil.isString(s)) {
     printToStdout(s)
   }
-  process.exit(0)
+  process.exitCode = 0;
 }
 
 function exitSad (s) {
   if (cliUtil.isString(s)) {
     printToStderr(s)
   }
-  process.exit(1)
+  process.exitCode = 1;
 }
 
 function formatDuration (durationMs) {


### PR DESCRIPTION
Fixes #213 

From Node.js docs:

> Calling process.exit() will force the process to exit as quickly as possible even if there are still asynchronous operations pending that have not yet completed fully, including I/O operations to process.stdout and process.stderr.

https://nodejs.org/docs/latest-v26.x/api/process.html#processexitcode

The issue can be reproduced when formatting a large file and using standard-clj in stdin/out mode and piping the result to another process.

Steps to reproduce:

```
bb -e '(spit "large-test.clj" (str/join "\n" (map #(str "(defn func-" % " [x] (+ x " % "))") (range 10000))))'
cat large-test.clj | node cli.mjs fix - | cat > large-test-output.clj
wc -l large-test.clj large-test-output.clj
    9999 large-test.clj
    2117 large-test-output.clj
   12116 total
```

Expected: Line count after formatting should be close to the original line count

Actual: The file is cut short. The line count of the formatted file is significantly less.

Please note that `| cat > ` is essential. This issue doesn't happen when stdout is redirected directly to a file, i.e.

It's worth noting that this change changes the semantics of exitHappy and exitSad function. The don't anymore exit immediately, but instead just set the exit code for the process. The exitHappy and exitSad function will return to the caller and if there's any code after calling exitHappy/Sad, that code will be executed. I checked the code and it seems to be that exitHappy/Sad calls are always the last piece of code and there's nothing after them, so this should be a safe change.